### PR TITLE
Add Intellij IDEA 2023.3.x supports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("212")
-        untilBuild.set("232.*")
+        untilBuild.set("233.*")
 
         pluginDescription.set(provider { file("description.html").readText() })
     }


### PR DESCRIPTION
6 December 2023 Intellij released version 2023.3, see more:  [IntelliJ IDEA 2023.3 (233.11799.241 build) Release Notes](https://youtrack.jetbrains.com/articles/IDEA-A-2100661779/IntelliJ-IDEA-2023.3-233.11799.241-build-Release-Notes?_gl=1*eung5g*_ga*MjAyOTk1NzU3My4xNjk1NzA3NjA1*_ga_9J976DJZ68*MTcwMTkxODYwOC40OS4xLjE3MDE5MjAzNzQuNTguMC4w&_ga=2.21180091.1649587274.1701657910-2029957573.1695707605)