### PR TITLE
code block skip verify code

### DIFF
--- a/src/main/java/com/zhongan/devpilot/completions/inline/CompletionPreview.java
+++ b/src/main/java/com/zhongan/devpilot/completions/inline/CompletionPreview.java
@@ -165,8 +165,10 @@ public class CompletionPreview implements Disposable {
 
         var name = file.getName();
         var fileExtension = name.substring(name.lastIndexOf(".") + 1);
-        suffix = TreeSitterParser.getInstance(fileExtension)
-                .parse(editor.getDocument().getText(), cursorOffset, suffix);
+        if (!suffix.contains("\n")) {
+            suffix = TreeSitterParser.getInstance(fileExtension)
+                    .parse(editor.getDocument().getText(), cursorOffset, suffix);
+        }
 
         editor.getDocument().insertString(cursorOffset, suffix);
         editor.getCaretModel().moveToOffset(startOffset + suffix.length());


### PR DESCRIPTION
When code is very long and have huge syntax error, it will cost lost of time to calculate, so we skip the code format when we generate multi line code