### PR TITLE
Wrap document operations in ReadAction and WriteAction for thread safety

### DIFF
--- a/src/main/java/com/zhongan/devpilot/completions/prediction/DevPilotCompletion.java
+++ b/src/main/java/com/zhongan/devpilot/completions/prediction/DevPilotCompletion.java
@@ -1,6 +1,8 @@
 package com.zhongan.devpilot.completions.prediction;
 
 import com.intellij.codeInsight.lookup.impl.LookupCellRenderer;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.util.containers.FList;
@@ -91,9 +93,13 @@ public class DevPilotCompletion implements Completion {
     }
 
     private String prepare(String suffix) {
-        int cursorOffset = editor.getCaretModel().getOffset();
+        int cursorOffset = ReadAction.compute(() ->
+                editor.getCaretModel().getOffset());
+
         if (shouldRemoveSuffix(this)) {
-            editor.getDocument().deleteString(cursorOffset, cursorOffset + this.oldSuffix.length());
+            WriteAction.runAndWait(() -> {
+                editor.getDocument().deleteString(cursorOffset, cursorOffset + this.oldSuffix.length());
+            });
         }
         return suffix;
     }


### PR DESCRIPTION
Refactored the prepare method in DevPilotCompletion to properly handle editor operations using ReadAction for reading cursor position and WriteAction for document modifications, preventing potential threading issues.